### PR TITLE
 successrate: Allow to pass log file as first arg     

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,37 @@
 
 This script calculates success rates for audits, downloads, uploads and repair traffic.
 
-_Note: If your container name is different from the default 'storagenode' you can pass it as an argument to the script. Example:_ `./successrate.sh storjv3`
+## How to use it
 
-_Note 2: If you have redirected the docker logs to a file you can change the LOG parameter to a cat command. Example can be found in the script._
+If your operative system can run _bash shell scripts_ then you can run directly the script, otherwise you can run it with the official [_bash_ docker image](https://hub.docker.com/_/bash).
+
+The script accept one optinal argument which is:
+
+a. The name of the docker storage node docker container.
+b. The path to a storage node log file.
+
+When the argument isn't provided, then it defauls to option (a) using _storagenode_ as a container name.
+
+### Examples running it directly
+
+Passing a docker container name: `./successrate.sh storjv3`
+
+Passing a log file: `./successrate.sh /data/storagenode.log`
+
+
+### Examples running it through docker
+
+Unfortunately, running it through a docker container you can only run it with option (b), passing a log file.
+
+```
+docker run --rm -v "<<path to successrate.sh folder>>:/tools" -v "<<path to the log file folder>>:/data" bash /tools/successrate.sh /data/storagenode.log
+```
+
+Remember to update the "<< path...>>" place holders of the above instruction to your correct local path directories.
+
 
 ## Locale error fix
-If you see errors like `./successrate.sh: line 68: printf: 99.8048: invalid number` try running the script with 
+If you see errors like `./successrate.sh: line 68: printf: 99.8048: invalid number` try running the script with
 ```
 LC_ALL=C ./successrate.sh
 ```

--- a/successrate.sh
+++ b/successrate.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 #A StorJ node monitor script: Initial version by turbostorjdsk / KernelPanick, adapted by BrightSilence, original grep statements by Alexey
 
-# assumes your docker container is named 'storagenode'. If not, pass it as the first argument, e.g.:
-# bash successrate.sh mynodename
-DOCKER_NODE_NAME="${1:-storagenode}"
-LOG="docker logs $DOCKER_NODE_NAME"
-#Log line can be edited using cat for SNO's who wrote their log to a file.
-#LOG="cat /volume1/storj/v3/data/node.log"
+LOG_SOURCE="${1}"
+
+if [ ! -z "${LOG_SOURCE}" ] && [ -e "${LOG_SOURCE}" ]
+then
+	# the first argument is passed and it's an existing log file
+	LOG="cat ${LOG_SOURCE}"
+else
+	# assumes your docker container is named 'storagenode'. If not, pass it as the first argument, e.g.:
+	# bash successrate.sh mynodename
+	DOCKER_NODE_NAME="${1:-storagenode}"
+	LOG="docker logs $DOCKER_NODE_NAME"
+fi
 
 #Node Success Rates
 


### PR DESCRIPTION
Modify the script to accept to pass a log file as first argument to allow people who uses a OS which cannot run the bash shell script to use a docker container for it.