### PR TITLE
fix for issue #10 - successrate.sh not working executed in a crontab

### DIFF
--- a/successrate.sh
+++ b/successrate.sh
@@ -22,7 +22,6 @@ fi
 PRINTF=$(which printf)
 
 #Node Success Rates
-echo "LOG: ${LOG_SOURCE}"
 echo -e "\e[96m========== AUDIT ============== \e[0m"
 #count of successful audits
 audit_success=$($LOG 2>&1 | grep GET_AUDIT | grep downloaded -c)

--- a/successrate.sh
+++ b/successrate.sh
@@ -19,8 +19,10 @@ else
 	LOG="docker logs $DOCKER_NODE_NAME"
 fi
 
-#Node Success Rates
+PRINTF=$(which printf)
 
+#Node Success Rates
+echo "LOG: ${LOG_SOURCE}"
 echo -e "\e[96m========== AUDIT ============== \e[0m"
 #count of successful audits
 audit_success=$($LOG 2>&1 | grep GET_AUDIT | grep downloaded -c)
@@ -31,19 +33,19 @@ audit_failed_crit=$($LOG 2>&1 | grep GET_AUDIT | grep failed | grep exist -c)
 #Ratio of Successful to Failed Audits
 if [ $(($audit_success+$audit_failed_crit+$audit_failed_warn)) -ge 1 ]
 then
-	audit_successrate=$(printf '%.3f\n' $(echo -e "$audit_success $audit_failed_crit $audit_failed_warn" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	audit_successrate=$($PRINTF '%.3f\n' $(echo -e "$audit_success $audit_failed_crit $audit_failed_warn" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	audit_successrate=0.000%
 fi
 if [ $(($audit_success+$audit_failed_crit+$audit_failed_warn)) -ge 1 ]
 then
-	audit_recfailrate=$(printf '%.3f\n' $(echo -e "$audit_failed_warn $audit_success $audit_failed_crit" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	audit_recfailrate=$($PRINTF '%.3f\n' $(echo -e "$audit_failed_warn $audit_success $audit_failed_crit" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	audit_recfailrate=0.000%
 fi
 if [ $(($audit_success+$audit_failed_crit+$audit_failed_warn)) -ge 1 ]
 then
-	audit_failrate=$(printf '%.3f\n' $(echo -e "$audit_failed_crit $audit_failed_warn $audit_success" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	audit_failrate=$($PRINTF '%.3f\n' $(echo -e "$audit_failed_crit $audit_failed_warn $audit_success" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	audit_failrate=0.000%
 fi
@@ -64,21 +66,21 @@ dl_failed=$($LOG 2>&1 | grep '"GET"' | grep 'download failed' -c)
 #Ratio of canceled Downloads
 if [ $(($dl_success+$dl_failed+$dl_canceled)) -ge 1 ]
 then
-	dl_canratio=$(printf '%.3f\n' $(echo -e "$dl_canceled $dl_success $dl_failed" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+        dl_canratio=$($PRINTF '%.3f\n' $(echo -e "$dl_canceled $dl_success $dl_failed" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	dl_canratio=0.000%
 fi
 #Ratio of Failed Downloads
 if [ $(($dl_success+$dl_failed+$dl_canceled)) -ge 1 ]
 then
-	dl_failratio=$(printf '%.3f\n' $(echo -e "$dl_failed $dl_success $dl_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	dl_failratio=$($PRINTF '%.3f\n' $(echo -e "$dl_failed $dl_success $dl_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	dl_failratio=0.000%
 fi
 #Ratio of Successful Downloads
 if [ $(($dl_success+$dl_failed+$dl_canceled)) -ge 1 ]
 then
-	dl_ratio=$(printf '%.3f\n' $(echo -e "$dl_success $dl_failed $dl_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	dl_ratio=$($PRINTF '%.3f\n' $(echo -e "$dl_success $dl_failed $dl_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	dl_ratio=0.000%
 fi
@@ -101,28 +103,28 @@ put_failed=$($LOG 2>&1 | grep '"PUT"' | grep 'upload failed' -c)
 #Ratio of Rejections
 if [ $(($put_success+$put_rejected+$put_canceled+$put_failed)) -ge 1 ]
 then
-	put_accept_ratio=$(printf '%.3f\n' $(echo -e "$put_rejected $put_success $put_canceled $put_failed" | awk '{print ( ($2 + $3 + $4) / ( $1 + $2 + $3 + $4 )) * 100 }'))%
+	put_accept_ratio=$($PRINTF '%.3f\n' $(echo -e "$put_rejected $put_success $put_canceled $put_failed" | awk '{print ( ($2 + $3 + $4) / ( $1 + $2 + $3 + $4 )) * 100 }'))%
 else
 	put_accept_ratio=0.000%
 fi
 #Ratio of Failed
 if [ $(($put_success+$put_rejected+$put_canceled+$put_failed)) -ge 1 ]
 then
-	put_fail_ratio=$(printf '%.3f\n' $(echo -e "$put_failed $put_success $put_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	put_fail_ratio=$($PRINTF '%.3f\n' $(echo -e "$put_failed $put_success $put_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	put_fail_ratio=0.000%
 fi
 #Ratio of canceled
 if [ $(($put_success+$put_rejected+$put_canceled+$put_failed)) -ge 1 ]
 then
-	put_cancel_ratio=$(printf '%.3f\n' $(echo -e "$put_canceled $put_failed $put_success" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	put_cancel_ratio=$($PRINTF '%.3f\n' $(echo -e "$put_canceled $put_failed $put_success" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	put_cancel_ratio=0.000%
 fi
 #Ratio of Success
 if [ $(($put_success+$put_failed+$put_canceled+$put_failed)) -ge 1 ]
 then
-	put_ratio=$(printf '%.3f\n' $(echo -e "$put_success $put_failed $put_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	put_ratio=$($PRINTF '%.3f\n' $(echo -e "$put_success $put_failed $put_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	put_ratio=0.000%
 fi
@@ -146,21 +148,21 @@ get_repair_canceled=$($LOG 2>&1 | grep GET_REPAIR | grep 'download canceled' -c)
 #Ratio of Fail GET_REPAIR
 if [ $(($get_repair_success+$get_repair_failed+$get_repair_canceled)) -ge 1 ]
 then
-	get_repair_failratio=$(printf '%.3f\n' $(echo -e "$get_repair_failed $get_repair_success $get_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	get_repair_failratio=$($PRINTF '%.3f\n' $(echo -e "$get_repair_failed $get_repair_success $get_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	get_repair_failratio=0.000%
 fi
 #Ratio of Cancel GET_REPAIR
 if [ $(($get_repair_success+$get_repair_failed+$get_repair_canceled)) -ge 1 ]
 then
-	get_repair_canratio=$(printf '%.3f\n' $(echo -e "$get_repair_canceled $get_repair_success $get_repair_failed" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	get_repair_canratio=$($PRINTF '%.3f\n' $(echo -e "$get_repair_canceled $get_repair_success $get_repair_failed" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	get_repair_canratio=0.000%
 fi
 #Ratio of Success GET_REPAIR
 if [ $(($get_repair_success+$get_repair_failed+$get_repair_canceled)) -ge 1 ]
 then
-	get_repair_ratio=$(printf '%.3f\n' $(echo -e "$get_repair_success $get_repair_failed $get_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	get_repair_ratio=$($PRINTF '%.3f\n' $(echo -e "$get_repair_success $get_repair_failed $get_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	get_repair_ratio=0.000%
 fi
@@ -181,21 +183,21 @@ put_repair_failed=$($LOG 2>&1 | grep PUT_REPAIR | grep 'upload failed' -c)
 #Ratio of Fail PUT_REPAIR
 if [ $(($put_repair_success+$put_repair_failed+$put_repair_canceled)) -ge 1 ]
 then
-	put_repair_failratio=$(printf '%.3f\n' $(echo -e "$put_repair_failed $put_repair_success $put_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	put_repair_failratio=$($PRINTF '%.3f\n' $(echo -e "$put_repair_failed $put_repair_success $put_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	put_repair_failratio=0.000%
 fi
 #Ratio of Cancel PUT_REPAIR
 if [ $(($put_repair_success+$put_repair_failed+$put_repair_canceled)) -ge 1 ]
 then
-	put_repair_canratio=$(printf '%.3f\n' $(echo -e "$put_repair_canceled $put_repair_success $put_repair_failed" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	put_repair_canratio=$($PRINTF '%.3f\n' $(echo -e "$put_repair_canceled $put_repair_success $put_repair_failed" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	put_repair_canratio=0.000%
 fi
 #Ratio of Success PUT_REPAIR
 if [ $(($put_repair_success+$put_repair_failed+$put_repair_canceled)) -ge 1 ]
 then
-	put_repair_ratio=$(printf '%.3f\n' $(echo -e "$put_repair_success $put_repair_failed $put_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
+	put_repair_ratio=$($PRINTF '%.3f\n' $(echo -e "$put_repair_success $put_repair_failed $put_repair_canceled" | awk '{print ( $1 / ( $1 + $2 + $3 )) * 100 }'))%
 else
 	put_repair_ratio=0.000%
 fi
@@ -214,14 +216,14 @@ delete_failed=$($LOG 2>&1 | grep 'delete failed' -c)
 #Ratio of Fail delete
 if [ $(($delete_success+$delete_failed)) -ge 1 ]
 then
-	delete_failratio=$(printf '%.3f\n' $(echo -e "$delete_failed $delete_success" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))%
+	delete_failratio=$($PRINTF '%.3f\n' $(echo -e "$delete_failed $delete_success" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))%
 else
 	delete_failratio=0.000%
 fi
 #Ratio of Success delete
 if [ $(($delete_success+$delete_failed)) -ge 1 ]
 then
-	delete_ratio=$(printf '%.3f\n' $(echo -e "$delete_success $delete_failed" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))%
+	delete_ratio=$($PRINTF '%.3f\n' $(echo -e "$delete_success $delete_failed" | awk '{print ( $1 / ( $1 + $2 )) * 100 }'))%
 else
 	delete_ratio=0.000%
 fi


### PR DESCRIPTION
Shells may provide a builtin printf command that superseeds the external command (i.e. /usr/bin/printf). This patch forces the use of the external command. 